### PR TITLE
Remove inputmode numeric from EuroField

### DIFF
--- a/erica_app/erica/__init__.py
+++ b/erica_app/erica/__init__.py
@@ -3,7 +3,6 @@ import time
 from fastapi import FastAPI
 from prometheus_client import Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
-from starlette.responses import JSONResponse
 
 from erica.pyeric.eric import verify_using_stick
 

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -291,11 +291,10 @@ class IdNrField(SteuerlotseStringField):
             self.data = ''.join(self.data)
 
 
-class EuroFieldWidget(NumericInputModeMixin, TextInput):
+class EuroFieldWidget(TextInput):
     """A simple Euro widget that uses Bootstrap features for nice looks."""
 
     def __call__(self, field, **kwargs):
-        kwargs = self.set_inputmode(kwargs)
         _add_classes_to_kwargs(kwargs, ['euro_field form-control'])
         kwargs['onwheel'] = 'this.blur()'
         markup_input = super(EuroFieldWidget, self).__call__(field, **kwargs)


### PR DESCRIPTION
# Short Description
The EuroField is knocking again at our door. Using `inputmode="numeric"` will spawn a keyboard with only digits on mobile devices. This does not allow mobile users to input fractional numbers. There is a `inputmode` `decimal`. However, this does also not reliable allow for the input of fractional numbers.
Therefore the inputmode is again removed from EuroFields.

# Changes
- Remove the input mode.