### PR TITLE
Decode buffer from eric in pyeric layer

### DIFF
--- a/erica_app/erica/pyeric/eric.py
+++ b/erica_app/erica/pyeric/eric.py
@@ -190,7 +190,7 @@ class EricWrapper(object):
         try:
             cert_handle = self.get_cert_handle()
 
-            return self._call_and_return_buffer_contents(fun_get_cert_properties, cert_handle,
+            return self._call_and_return_buffer_contents_and_decode(fun_get_cert_properties, cert_handle,
                                                          EricWrapper.cert_pin.encode())
         finally:
             if cert_handle:
@@ -305,7 +305,7 @@ class EricWrapper(object):
         try:
             cert_handle = self.get_cert_handle()
 
-            return self._call_and_return_buffer_contents(
+            return self._call_and_return_buffer_contents_and_decode(
                 fun_decrypt_data,
                 cert_handle,
                 EricWrapper.cert_pin.encode(),
@@ -325,7 +325,7 @@ class EricWrapper(object):
         fun_get_tax_offices.argtypes = [c_void_p, c_char_p, c_void_p]
         fun_get_tax_offices.restype = int
 
-        return self._call_and_return_buffer_contents(
+        return self._call_and_return_buffer_contents_and_decode(
             fun_get_tax_offices,
             state_id.encode())
 
@@ -338,7 +338,7 @@ class EricWrapper(object):
         fun_get_tax_offices.argtypes = [c_void_p, c_void_p]
         fun_get_tax_offices.restype = int
 
-        return self._call_and_return_buffer_contents(
+        return self._call_and_return_buffer_contents_and_decode(
             fun_get_tax_offices)
 
     def _call_and_return_buffer_contents(self, function, *args):
@@ -357,6 +357,15 @@ class EricWrapper(object):
             return returned_xml
         finally:
             self.close_buffer(buf)
+
+    def _call_and_return_buffer_contents_and_decode(self, function, *args):
+        """
+        This calls the ERIC function, reads the buffer and decodes the returned_xml.
+
+        :param function: The ERIC function to be called. The argtypes and restype have to be set before.
+        """
+
+        return self._call_and_return_buffer_contents(function, *args).decode()
 
     def get_error_message_from_xml_response(self, xml_response):
         """Extract error message from server response"""

--- a/erica_app/erica/pyeric/pyeric_controller.py
+++ b/erica_app/erica/pyeric/pyeric_controller.py
@@ -165,11 +165,11 @@ class GetTaxOfficesPyericController:
         with get_eric_wrapper() as eric_wrapper:
             pyeric_response = eric_wrapper.get_state_id_list()
 
-        return GetTaxOfficesPyericController.standardise_state_id_list(get_state_ids(pyeric_response.decode()))
+        return GetTaxOfficesPyericController.standardise_state_id_list(get_state_ids(pyeric_response))
 
     @staticmethod
     def _request_tax_offices(state_id):
         with get_eric_wrapper() as eric_wrapper:
             pyeric_response = eric_wrapper.get_tax_offices(state_id)
 
-        return get_tax_offices(pyeric_response.decode())
+        return get_tax_offices(pyeric_response)

--- a/erica_app/tests/pyeric/test_eric.py
+++ b/erica_app/tests/pyeric/test_eric.py
@@ -919,7 +919,7 @@ class TestDecryptData(unittest.TestCase):
         self.mock_fun_decode_successful.reset_mock()
 
         buffer_contents = {}
-        buffer = r"<text>Send it over into ELSTER land \o/ </text>"
+        buffer = b"<text>Send it over into ELSTER land \o/ </text>"
 
         def _change_buffer_contents(*args):
             buffer_contents[args[4]] = buffer
@@ -932,7 +932,7 @@ class TestDecryptData(unittest.TestCase):
 
         result = self.eric_api_with_mocked_binaries.decrypt_data(self.encrypted_data)
 
-        self.assertEqual(buffer, result)
+        self.assertEqual(buffer.decode(), result)
 
 
 class TestGetTaxOffices(unittest.TestCase):
@@ -975,7 +975,7 @@ class TestGetTaxOffices(unittest.TestCase):
         self.mock_fun_hole_finanzaemter_unsuccessful.reset_mock()
 
         buffer_contents = {}
-        buffer = r"<text>Send it over into ELSTER land \o/ </text>"
+        buffer = b"<text>Send it over into ELSTER land \o/ </text>"
 
         def _change_buffer_contents(*args):
             buffer_contents[args[2]] = buffer
@@ -988,7 +988,7 @@ class TestGetTaxOffices(unittest.TestCase):
 
         result = self.eric_api_with_mocked_binaries.get_tax_offices(self.state_code)
 
-        self.assertEqual(buffer, result)
+        self.assertEqual(buffer.decode(), result)
 
 
 class TestGetstateIdList(unittest.TestCase):
@@ -1029,7 +1029,7 @@ class TestGetstateIdList(unittest.TestCase):
         self.mock_fun_hole_finanzamtlandnummern_unsuccessful.reset_mock()
 
         buffer_contents = {}
-        buffer = r"<text>Send it over into ELSTER land \o/ </text>"
+        buffer = b"<text>Send it over into ELSTER land \o/ </text>"
 
         def _change_buffer_contents(*args):
             buffer_contents[args[1]] = buffer
@@ -1042,7 +1042,7 @@ class TestGetstateIdList(unittest.TestCase):
 
         result = self.eric_api_with_mocked_binaries.get_state_id_list()
 
-        self.assertEqual(buffer, result)
+        self.assertEqual(buffer.decode(), result)
 
 
 class TestGetErrorMessageFromXml(unittest.TestCase):
@@ -1150,9 +1150,9 @@ class TestGetCertProperties(unittest.TestCase):
             cert_properties = eric_wrapper.get_cert_properties()
 
         # Verify some expected content is there.
-        self.assertTrue("EricHoleZertifikatEigenschaften" in cert_properties.decode())
-        self.assertTrue("Signaturzertifikateigenschaften" in cert_properties.decode())
-        self.assertTrue("ElsterIdNrSoftTestCA" in cert_properties.decode())
+        self.assertTrue("EricHoleZertifikatEigenschaften" in cert_properties)
+        self.assertTrue("Signaturzertifikateigenschaften" in cert_properties)
+        self.assertTrue("ElsterIdNrSoftTestCA" in cert_properties)
 
     def test_should_raise_error_when_non_zero_result(self):
         self.eric_wrapper_with_mock_eric_binaries.eric.EricMtHoleZertifikatEigenschaften.return_value = -1


### PR DESCRIPTION
# Short Description
With the introduction of '_call_and_return_buffer_contents_and_decode' we have a problem because the data from Eric isn't decoded properly for `verify_using_stick`. This resulted in an error on staging.

Instead of having to decode every time we get data from the pyeric layer, we already decode in the corresponding Eric functions. However, some of the functions already return a string and not bytes. I have therefore added a separate function `_call_and_return_buffer_contents_and_decode` which decodes and call this one explicitly when we want to decode.

**NOTE**: I am going to merge this to ensure that it solves our problem on staging.

# Changes
- Add and use `_call_and_return_buffer_contents_and_decode`
- Adapt some of the tests and functions that had to decode before

# Feedback
- Any problems with the extra function? Would you rather check inside `_call_and_return_buffer_contents` if the result is bytes or do you see a better alternative?
