### PR TITLE
Remove outdated acceptance test

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -651,12 +651,6 @@ context('Acceptance tests', () => {
                 expect(loc.pathname.toString()).to.contain('/lotse/step/vorsorge');
             });
 
-            // Redirect gem_haushalt
-            cy.visit('/lotse/step/gem_haushalt?link_overview=True')
-            cy.location().should((loc) => {
-                expect(loc.pathname.toString()).to.contain('/lotse/step/familienstand');
-            });
-
 
             // Set familienstand divorced
             cy.visit('/lotse/step/familienstand')

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -2555,7 +2555,7 @@ msgstr "Gemeinsamer Haushalt"
 msgid "form.lotse.skip_reason.stmind_gem_haushalt.no_handwerker_haushaltsnahe"
 msgstr ""
 "Bitte überspringen Sie diese Angaben. Die Angabe zum gemeinsamen Haushalt"
-" ist nur relevant, wenn Sie Angaben zu haushaltsnaheh Tätigkeiten und "
+" ist nur relevant, wenn Sie Angaben zu haushaltsnahen Tätigkeiten und "
 "Dienstleistungen und/oder Handwerkerleistungen machen."
 
 #: app/forms/steps/lotse_multistep_flow_steps/steuerminderungen_steps.py:262


### PR DESCRIPTION
Previously, the current familienstand would have led to a redirect. This is now not the case anymore, so I removed the test.
Plus, perspectively we wanted to get rid of the redirect acceptance tests anyways. The unit tests that I wrote in #247 should cover this enough.