### PR TITLE
Disallow concurrent ci pipeline runs for the same branch

### DIFF
--- a/.github/workflows/cicd-pipeline.yml
+++ b/.github/workflows/cicd-pipeline.yml
@@ -2,6 +2,10 @@ name: CI/CD Pipeline
 
 on: push
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
   ERICA_HOST: ${{ secrets.ERICA_HOST_STAGING }}


### PR DESCRIPTION
# Short Description
- Our acceptance tests flicker: they are sometimes red and then green again without code change.
- Testing locally, it seemed like this may me due to concurrent runs: starting two acceptance test runs against staging simultaneously caused one of them to fail, with the same error message we get in CI.
- We also know that running multiple staging deploys simultaneously sometimes fails because erica deployments are not well isolated.
- Enter: concurrency locking of the CI/CD pipeline https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency.
- This allows only **one** build to be in progress for the whole pipeline _per branch_. I think it works like this:
  - Someone merges branch A to main: this will now run the pipeline, a "run A" will now be in progress.
  - Someone merges branches B and C to main: B & C will not start immediately but be pending.
  - Github actions will cancel the runs for branches A & B and start the build for branch C.
  - If someone now pushes a new branch D, Github Actions will still run the pipeline (skipping deployment as usual) for that branch because concurrency is only locked _per branch_.

# Changes
- Configure concurrency locking for the CI/CD pipeline.

# Feedback
- I've already merged this so I can test it, but I'm interested in what you think of this!