### PR TITLE
Stl 2200 revise vorbereiten pages

### DIFF
--- a/webapp/client/src/components/AccordionComponent.js
+++ b/webapp/client/src/components/AccordionComponent.js
@@ -60,6 +60,11 @@ const CardHeaderSpan = styled.span`
 
 const AccordionHeadline = styled.h2`
   margin-bottom: var(--spacing-05);
+  font-size: var(--text-3xl);
+
+  @media (max-width: 1024px) {
+    font-size: var(--text-xla);
+  }
 `;
 
 const AccordionStyled = styled(Accordion)``;

--- a/webapp/client/src/components/ContentPagesGeneralStyling.js
+++ b/webapp/client/src/components/ContentPagesGeneralStyling.js
@@ -75,7 +75,7 @@ export const Paragraph = styled.p`
   padding-top: ${(props) =>
     props.spacingVariant ? "var(--spacing-08)" : "var(--spacing-03)"};
   margin: 0;
-  font-size: var(--text-medium-big);
+  font-size: var(--text-medium);
 `;
 
 export const ParagraphLarge = styled(Paragraph)`

--- a/webapp/client/src/pages/CareCostsInfoPage.js
+++ b/webapp/client/src/pages/CareCostsInfoPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../components/InfoBox";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -13,10 +14,8 @@ import {
   List,
   AnchorListItem,
   ListItem,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function CareCostsInfoPage() {
@@ -47,8 +46,10 @@ export default function CareCostsInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("CareCostsInfo.Paragraph1.Heading")}</Headline1>
-        <ParagraphLarge>{t("CareCostsInfo.Paragraph1.Text")}</ParagraphLarge>
+        <FormHeader
+          title={t("CareCostsInfo.Paragraph1.Heading")}
+          intro={t("CareCostsInfo.Paragraph1.Text")}
+        />
         <Headline2>{t("CareCostsInfo.Paragraph2.Heading")}</Headline2>
         <List aria-label="simple-list">{listCareCostItemsMap}</List>
         <Headline2>{t("CareCostsInfo.Paragraph3.Heading")}</Headline2>

--- a/webapp/client/src/pages/ChurchTaxInfoPage.js
+++ b/webapp/client/src/pages/ChurchTaxInfoPage.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { t } from "i18next";
 import InfoBox from "../components/InfoBox";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -11,11 +12,9 @@ import StepHeaderButtons from "../components/StepHeaderButtons";
 import {
   AnchorListItem,
   ContentWrapper,
-  Headline1,
   Headline2,
   List,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function ChurchTaxInfoPage() {
@@ -31,8 +30,10 @@ export default function ChurchTaxInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("Kirchensteuer.Section1.heading")}</Headline1>
-        <ParagraphLarge>{t("Kirchensteuer.Section1.text")}</ParagraphLarge>
+        <FormHeader
+          title={t("Kirchensteuer.Section1.heading")}
+          intro={t("Kirchensteuer.Section1.text")}
+        />
         <Headline2>{t("Kirchensteuer.Section2.heading")}</Headline2>
         <Paragraph>{t("Kirchensteuer.Section2.text")}</Paragraph>
         <Headline2>{t("Kirchensteuer.Section3.heading")}</Headline2>

--- a/webapp/client/src/pages/CraftsmanServicesInfoPage.js
+++ b/webapp/client/src/pages/CraftsmanServicesInfoPage.js
@@ -2,6 +2,8 @@ import React from "react";
 import { t } from "i18next";
 import { Trans } from "react-i18next";
 import InfoBox from "../components/InfoBox";
+import FormHeader from "../components/FormHeader";
+
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -12,12 +14,10 @@ import StepHeaderButtons from "../components/StepHeaderButtons";
 import {
   AnchorListItem,
   ContentWrapper,
-  Headline1,
   Headline2,
   List,
   ListItem,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function CraftsmanServicesInfoPage() {
@@ -65,10 +65,10 @@ export default function CraftsmanServicesInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("Handwerkerleistungen.Section1.heading")}</Headline1>
-        <ParagraphLarge>
-          {t("Handwerkerleistungen.Section1.text")}
-        </ParagraphLarge>
+        <FormHeader
+          title={t("Handwerkerleistungen.Section1.heading")}
+          intro={t("Handwerkerleistungen.Section1.text")}
+        />
         <Headline2>{t("Handwerkerleistungen.Section2.heading")}</Headline2>
         <Paragraph>{t("Handwerkerleistungen.Section2.text")}</Paragraph>
         <List aria-label="simple-list">{listItemsMap}</List>

--- a/webapp/client/src/pages/DisabilityCostsInfoPage.js
+++ b/webapp/client/src/pages/DisabilityCostsInfoPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../components/InfoBox";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -13,10 +14,8 @@ import {
   List,
   AnchorListItem,
   ListItem,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function DisabilityCostsInfoPage() {
@@ -69,12 +68,10 @@ export default function DisabilityCostsInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-
-        <Headline1>{t("DisabilityCostsInfo.Section1.Heading")}</Headline1>
-        <ParagraphLarge>
-          {t("DisabilityCostsInfo.Section1.Text")}
-        </ParagraphLarge>
-
+        <FormHeader
+          title={t("DisabilityCostsInfo.Section1.Heading")}
+          intro={t("DisabilityCostsInfo.Section1.Text")}
+        />
         <Headline2>{t("DisabilityCostsInfo.Section2.Heading")}</Headline2>
         <Paragraph>{t("DisabilityCostsInfo.Section2.Text")}</Paragraph>
 

--- a/webapp/client/src/pages/DonationInfoPage.js
+++ b/webapp/client/src/pages/DonationInfoPage.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { t } from "i18next";
 import InfoBox from "../components/InfoBox";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -11,12 +12,10 @@ import StepHeaderButtons from "../components/StepHeaderButtons";
 import {
   AnchorListItem,
   ContentWrapper,
-  Headline1,
   Headline2,
   List,
   ListItem,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function DonationInfoPage() {
@@ -72,8 +71,10 @@ export default function DonationInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("Spenden.Section1.heading")}</Headline1>
-        <ParagraphLarge>{t("Spenden.Section1.text")}</ParagraphLarge>
+        <FormHeader
+          title={t("Spenden.Section1.heading")}
+          intro={t("Spenden.Section1.text")}
+        />
         <Headline2>{t("Spenden.Section2.heading")}</Headline2>
         <Paragraph>{t("Spenden.Section2.text")}</Paragraph>
         <List aria-label="simple-list">{listItemsMap}</List>

--- a/webapp/client/src/pages/FuneralExpensesInfoPage.js
+++ b/webapp/client/src/pages/FuneralExpensesInfoPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../components/InfoBox";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -13,10 +14,8 @@ import {
   List,
   AnchorListItem,
   ListItem,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function FuneralExpensesInfoPage() {
@@ -69,8 +68,10 @@ export default function FuneralExpensesInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("Bestattungskosten.Section1.heading")}</Headline1>
-        <ParagraphLarge>{t("Bestattungskosten.Section1.text")}</ParagraphLarge>
+        <FormHeader
+          title={t("Bestattungskosten.Section1.heading")}
+          intro={t("Bestattungskosten.Section1.text")}
+        />
         <Headline2>{t("Bestattungskosten.Section2.heading")}</Headline2>
         <Paragraph>{t("Bestattungskosten.Section2.text")}</Paragraph>
         <List aria-label="simple-list">{listDeductablesItemsMap}</List>

--- a/webapp/client/src/pages/HouseholdServicesInfoPage.js
+++ b/webapp/client/src/pages/HouseholdServicesInfoPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../components/InfoBox";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -13,10 +14,8 @@ import {
   List,
   AnchorListItem,
   ListItem,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function HouseholdServicesInfoPage() {
@@ -65,10 +64,10 @@ export default function HouseholdServicesInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("HouseholdServicesInfo.Section1.Heading")}</Headline1>
-        <ParagraphLarge>
-          {t("HouseholdServicesInfo.Section1.Text")}
-        </ParagraphLarge>
+        <FormHeader
+          title={t("HouseholdServicesInfo.Section1.Heading")}
+          intro={t("HouseholdServicesInfo.Section1.Text")}
+        />
         <Headline2>{t("HouseholdServicesInfo.Section2.Heading")}</Headline2>
         <Paragraph>{t("HouseholdServicesInfo.Section2.Text")}</Paragraph>
         <List aria-label="simple-list">{listHouseholdServicessMap}</List>

--- a/webapp/client/src/pages/MedicalExpensesInfoPage.js
+++ b/webapp/client/src/pages/MedicalExpensesInfoPage.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { t } from "i18next";
 import InfoBox from "../components/InfoBox";
+import FormHeader from "../components/FormHeader";
+
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -11,12 +13,10 @@ import StepHeaderButtons from "../components/StepHeaderButtons";
 import {
   AnchorListItem,
   ContentWrapper,
-  Headline1,
   Headline2,
   List,
   ListItem,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function MedicalExpensesInfoPage() {
@@ -55,8 +55,12 @@ export default function MedicalExpensesInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("Krankheitskosten.Paragraph1.heading")}</Headline1>
-        <ParagraphLarge>{t("Krankheitskosten.Paragraph1.text")}</ParagraphLarge>
+
+        <FormHeader
+          title={t("Krankheitskosten.Paragraph1.heading")}
+          intro={t("Krankheitskosten.Paragraph1.text")}
+        />
+
         <Headline2>{t("Krankheitskosten.Paragraph2.heading")}</Headline2>
         <List aria-label="simple-list">{listItemsMap}</List>
         <Headline2>{t("Krankheitskosten.Paragraph3.heading")}</Headline2>

--- a/webapp/client/src/pages/PensionExpensesInfoPage.js
+++ b/webapp/client/src/pages/PensionExpensesInfoPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../components/InfoBox";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -13,10 +14,8 @@ import {
   List,
   AnchorListItem,
   ListItem,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function PensionExpensesInfoPage() {
@@ -78,10 +77,10 @@ export default function PensionExpensesInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("Vorsorgeaufwendungen.Paragraph1.Heading")}</Headline1>
-        <ParagraphLarge>
-          {t("Vorsorgeaufwendungen.Paragraph1.Text")}
-        </ParagraphLarge>
+        <FormHeader
+          title={t("Vorsorgeaufwendungen.Paragraph1.Heading")}
+          intro={t("Vorsorgeaufwendungen.Paragraph1.Text")}
+        />
         <Headline2>{t("Vorsorgeaufwendungen.Paragraph2.Heading")}</Headline2>
         <List aria-label="first-list">{listDeductablesItemsMap}</List>
         <Headline2>{t("Vorsorgeaufwendungen.Paragraph3.Heading")}</Headline2>

--- a/webapp/client/src/pages/ReplacementCostsInfoPage.js
+++ b/webapp/client/src/pages/ReplacementCostsInfoPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../components/InfoBox";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormHeader from "../components/FormHeader";
 // eslint-disable-next-line import/named
 import {
   anchorBack,
@@ -12,10 +13,8 @@ import {
   ContentWrapper,
   List,
   AnchorListItem,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function ReplacementCostsInfoPage() {
@@ -33,10 +32,10 @@ export default function ReplacementCostsInfoPage() {
     <>
       <ContentWrapper>
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
-        <Headline1>{t("ReplacementCostsInfo.Section1.Heading")}</Headline1>
-        <ParagraphLarge>
-          {t("ReplacementCostsInfo.Section1.Text")}
-        </ParagraphLarge>
+        <FormHeader
+          title={t("ReplacementCostsInfo.Section1.Heading")}
+          intro={t("ReplacementCostsInfo.Section1.Text")}
+        />
         <Headline2>{t("ReplacementCostsInfo.Section2.Heading")}</Headline2>
         <Paragraph>{t("ReplacementCostsInfo.Section2.Text")}</Paragraph>
         <Paragraph>{t("ReplacementCostsInfo.Section2.Text2")}</Paragraph>

--- a/webapp/client/src/pages/VorbereitenOverviewPage.js
+++ b/webapp/client/src/pages/VorbereitenOverviewPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { t } from "i18next";
 import PropTypes from "prop-types";
+import FormHeader from "../components/FormHeader";
 import InfoBox from "../components/InfoBox";
 import AccordionComponent from "../components/AccordionComponent";
 import TileCard from "../components/TileCard";
@@ -18,10 +19,8 @@ import SpendenUndMitgliedsbeitraegeIcon from "../assets/icons/spenden_und_mitgli
 import KirchensteuerIcon from "../assets/icons/kirchensteuer.svg";
 import {
   ContentWrapper,
-  Headline1,
   Headline2,
   Paragraph,
-  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 import ButtonAnchor from "../components/ButtonAnchor";
 import { anchorRegister } from "../lib/contentPagesAnchors";
@@ -46,13 +45,13 @@ const ButtonAnchorOverview = styled(ButtonAnchor)`
   margin-top: var(--spacing-04);
 `;
 
-const Headline1Overview = styled(Headline1)`
-  margin-top: var(--spacing-09);
+// const Headline1Overview = styled(Headline1)`
+//   margin-top: var(--spacing-09);
 
-  @media screen and (min-width: 1024px) {
-    margin-top: var(--spacing-11);
-  }
-`;
+//   @media screen and (min-width: 1024px) {
+//     margin-top: var(--spacing-11);
+//   }
+// `;
 
 export default function VorbereitenOverviewPage({
   downloadPreparationLink,
@@ -72,12 +71,10 @@ export default function VorbereitenOverviewPage({
   return (
     <>
       <ContentWrapper>
-        <Headline1Overview>
-          {t("vorbereitenOverview.Paragraph1.heading")}
-        </Headline1Overview>
-        <ParagraphLarge>
-          {t("vorbereitenOverview.Paragraph1.text")}
-        </ParagraphLarge>
+        <FormHeader
+          title={t("vorbereitenOverview.Paragraph1.heading")}
+          intro={t("vorbereitenOverview.Paragraph1.text")}
+        />
         <Headline2>{t("vorbereitenOverview.Paragraph2.heading")}</Headline2>
         <Paragraph>{t("vorbereitenOverview.Paragraph2.text")}</Paragraph>
         <ButtonAnchorOverview url={downloadPreparationLink} download>

--- a/webapp/client/src/pages/VorbereitenOverviewPage.js
+++ b/webapp/client/src/pages/VorbereitenOverviewPage.js
@@ -45,14 +45,6 @@ const ButtonAnchorOverview = styled(ButtonAnchor)`
   margin-top: var(--spacing-04);
 `;
 
-// const Headline1Overview = styled(Headline1)`
-//   margin-top: var(--spacing-09);
-
-//   @media screen and (min-width: 1024px) {
-//     margin-top: var(--spacing-11);
-//   }
-// `;
-
 export default function VorbereitenOverviewPage({
   downloadPreparationLink,
   vorsorgeaufwendungenUrl,


### PR DESCRIPTION
# Short Description
- standardised the heading and paragraph fontSizes, the margins across all Vorbereiten sub pages

# Changes
- reuses the FormHeader component for each page to standardise the intro headings and paragraphs
- adjusted the font size for paragraphs

# Feedback
- any

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
