### PR TITLE
STL-2509-adding plausible tracking to the subscribe to newsletter button

### DIFF
--- a/webapp/client/src/components/NewsletterRegisterBox.js
+++ b/webapp/client/src/components/NewsletterRegisterBox.js
@@ -133,7 +133,12 @@ const errors = [];
 let emailValue = "";
 let disableButton = false;
 
-export default function NewsletterRegisterBox({ dataPrivacyLink, csrfToken }) {
+export default function NewsletterRegisterBox({
+  dataPrivacyLink,
+  csrfToken,
+  plausibleDomain,
+  plausibleGoal,
+}) {
   const { t } = useTranslation();
 
   function displaySuccessBox(activate) {
@@ -218,7 +223,12 @@ export default function NewsletterRegisterBox({ dataPrivacyLink, csrfToken }) {
             />
           </ColumnField>
           <ColumnButton flexBasis={30} leftAuto>
-            <ButtonInRow onClick={sendEmail} disabled={disableButton}>
+            <ButtonInRow
+              onClick={sendEmail}
+              disabled={disableButton}
+              plausibleDomain={plausibleDomain}
+              plausibleGoal={plausibleGoal}
+            >
               {t("newsletter.button.label")}
             </ButtonInRow>
           </ColumnButton>
@@ -255,4 +265,11 @@ export default function NewsletterRegisterBox({ dataPrivacyLink, csrfToken }) {
 NewsletterRegisterBox.propTypes = {
   dataPrivacyLink: PropTypes.string.isRequired,
   csrfToken: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+  plausibleGoal: PropTypes.string,
+};
+
+NewsletterRegisterBox.defaultProps = {
+  plausibleDomain: null,
+  plausibleGoal: null,
 };

--- a/webapp/client/src/pages/UnlockCodeSuccessPage.js
+++ b/webapp/client/src/pages/UnlockCodeSuccessPage.js
@@ -60,6 +60,7 @@ export default function UnlockCodeSuccessPage({
   };
 
   const plausibleGoal = "Vorbereitungshilfe";
+  const emailPlausibleGoal = "E-Mails abonnieren";
   const plausiblePropsButton = {
     method: "CTA Vorbereitungshilfe herunterladen",
   };
@@ -110,6 +111,8 @@ export default function UnlockCodeSuccessPage({
       <NewsletterRegisterBox
         dataPrivacyLink={dataPrivacyLink}
         csrfToken={csrfToken}
+        plausibleDomain={plausibleDomain}
+        plausibleGoal={emailPlausibleGoal}
       />
     </>
   );


### PR DESCRIPTION
# Short Description
- adds a plausible goal for the subscribe to newsletter button so we can track the numbers

# Changes
- adds the plausible goal for sending emails to unlockCodeSuccessPage
- adds plausibleDomain and plausibleGoal to the NewsletterRegisterBox button
 
# Feedback
- anything missed for plausible tracking to work?

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
