### PR TITLE
STL-2509-Adding plausible tracking to successful email registrations only

### DIFF
--- a/webapp/app/model/components/__init__.py
+++ b/webapp/app/model/components/__init__.py
@@ -93,7 +93,7 @@ class RegistrationProps(StepFormProps):
     data_privacy_link: str
 
 
-class UnlockCodeSuccessProps(ComponentProps):
+class UnlockCodeSuccessProps(ComponentPlausibleProps):
     prev_url: Optional[str]
     steuer_erklaerung_link: str
     vorbereitungs_hilfe_link: str

--- a/webapp/app/model/components/__init__.py
+++ b/webapp/app/model/components/__init__.py
@@ -97,7 +97,6 @@ class UnlockCodeSuccessProps(ComponentPlausibleProps):
     prev_url: Optional[str]
     steuer_erklaerung_link: str
     vorbereitungs_hilfe_link: str
-    plausible_domain: Optional[str]
     data_privacy_link: str
     csrf_token: str
 

--- a/webapp/client/src/components/NewsletterRegisterBox.js
+++ b/webapp/client/src/components/NewsletterRegisterBox.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import ButtonAnchor from "./ButtonAnchor";
 import FormFieldTextInput from "./FormFieldTextInput";
 import { ReactComponent as SuccessIcon } from "../assets/icons/success_icon.svg";
+import addPlausibleGoal from "../lib/helpers";
 
 const Box = styled.div`
   background-color: var(--beige-200);
@@ -138,6 +139,7 @@ export default function NewsletterRegisterBox({
   csrfToken,
   plausibleDomain,
   plausibleGoal,
+  plausibleProps,
 }) {
   const { t } = useTranslation();
 
@@ -145,6 +147,9 @@ export default function NewsletterRegisterBox({
     const x = document.getElementById("success");
     if (activate) {
       x.style.display = "block";
+      addPlausibleGoal(plausibleDomain, plausibleGoal, {
+        props: plausibleProps,
+      });
     } else {
       x.style.display = "none";
     }
@@ -223,12 +228,7 @@ export default function NewsletterRegisterBox({
             />
           </ColumnField>
           <ColumnButton flexBasis={30} leftAuto>
-            <ButtonInRow
-              onClick={sendEmail}
-              disabled={disableButton}
-              plausibleDomain={plausibleDomain}
-              plausibleGoal={plausibleGoal}
-            >
+            <ButtonInRow onClick={sendEmail} disabled={disableButton}>
               {t("newsletter.button.label")}
             </ButtonInRow>
           </ColumnButton>
@@ -267,9 +267,11 @@ NewsletterRegisterBox.propTypes = {
   csrfToken: PropTypes.string.isRequired,
   plausibleDomain: PropTypes.string,
   plausibleGoal: PropTypes.string,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
 };
 
 NewsletterRegisterBox.defaultProps = {
   plausibleDomain: null,
   plausibleGoal: null,
+  plausibleProps: undefined,
 };

--- a/webapp/client/src/components/NewsletterRegisterBox.js
+++ b/webapp/client/src/components/NewsletterRegisterBox.js
@@ -139,7 +139,6 @@ export default function NewsletterRegisterBox({
   csrfToken,
   plausibleDomain,
   plausibleGoal,
-  plausibleProps,
 }) {
   const { t } = useTranslation();
 
@@ -147,9 +146,7 @@ export default function NewsletterRegisterBox({
     const x = document.getElementById("success");
     if (activate) {
       x.style.display = "block";
-      addPlausibleGoal(plausibleDomain, plausibleGoal, {
-        props: plausibleProps,
-      });
+      addPlausibleGoal(plausibleDomain, plausibleGoal, {});
     } else {
       x.style.display = "none";
     }
@@ -267,11 +264,9 @@ NewsletterRegisterBox.propTypes = {
   csrfToken: PropTypes.string.isRequired,
   plausibleDomain: PropTypes.string,
   plausibleGoal: PropTypes.string,
-  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
 };
 
 NewsletterRegisterBox.defaultProps = {
   plausibleDomain: null,
   plausibleGoal: null,
-  plausibleProps: undefined,
 };


### PR DESCRIPTION

# Short Description
- With tracking the button we do not track if the users actually registered successfully. This way we link the tracking to showing the success message instead of clicking the button.

# Changes
- calls addPlausibleGoal if the success box is active

# Feedback
- is this the correct way to track this?

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
