### PR TITLE
Stl 2572 improve communication through errors messages

### DIFF
--- a/webapp/app/forms/validations/validators.py
+++ b/webapp/app/forms/validations/validators.py
@@ -119,6 +119,9 @@ class ValidUnlockCode:
             raise ValidationError(_('validate.unlock-code-length'))
 
         input_str = str(field.data)
+        # must not equal example-code
+        if (input_str == 'KPWT-7R2F-HGS'):
+            raise ValidationError(_('validate.unlock-code.not.example-code'))    
         # must contain 14 digits
         if len(input_str) != 14:
             raise ValidationError(_('validate.unlock-code-length'))

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-07-05 11:44+0200\n"
+"POT-Creation-Date: 2022-07-21 23:28+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -2973,7 +2973,7 @@ msgid "validate.date-of-too-far-in-past"
 msgstr "Das Datum darf nicht vor dem 1.1.1900 liegen."
 
 #: app/forms/validations/validators.py:25
-#: app/forms/validations/validators.py:189
+#: app/forms/validations/validators.py:192
 msgid "validate.not-a-decimal"
 msgstr "Der Wert darf nur Ziffern beinhalten."
 
@@ -3031,35 +3031,41 @@ msgstr ""
 msgid "validate.invalid-unlock-code"
 msgstr "Der Freischaltcode ist nicht valide."
 
-#: app/forms/validations/validators.py:137
-#: app/forms/validations/validators.py:147
+#: app/forms/validations/validators.py:130
+msgid "validate.unlock-code.not.example-code"
+msgstr ""
+"Der eingegebene Freischaltcode entspricht dem Beispiel-Freischaltcode. "
+"Sie erhalten Ihren persönlichen Freischaltcode in einem Brief."
+
+#: app/forms/validations/validators.py:140
+#: app/forms/validations/validators.py:150
 msgid "validate.invalid-character"
 msgstr "Das Feld enthält ein Zeichen, das nicht unterstützt wird."
 
-#: app/forms/validations/validators.py:159
+#: app/forms/validations/validators.py:162
 msgid "validate.invalid-tax-number-length.shorter-than-ten"
 msgstr "Die Angabe muss mindestens 10 Ziffern umfassen."
 
-#: app/forms/validations/validators.py:161
+#: app/forms/validations/validators.py:164
 msgid "validate.invalid-tax-number-length.shorter-than-eleven"
 msgstr "Die Angabe muss mindestens 11 Ziffern umfassen."
 
-#: app/forms/validations/validators.py:163
+#: app/forms/validations/validators.py:166
 msgid "validate.invalid-tax-number-length.too-long"
 msgstr "Die Angabe darf höchstens 11 Ziffern umfassen."
 
-#: app/forms/validations/validators.py:172
+#: app/forms/validations/validators.py:175
 msgid "validate.invalid-hessen-tax-number"
 msgstr ""
 "In Hessen gibt es verschiedene Formate für die Steuernummer. Sollte die "
 "Ihnen vorliegende Nummer 10 Ziffern haben, tragen Sie bitte an erster "
 "Stelle eine 0 ein."
 
-#: app/forms/validations/validators.py:180
+#: app/forms/validations/validators.py:183
 msgid "validate.invalid-tax-number"
 msgstr "Die Steuernummer ist nicht valide."
 
-#: app/forms/validations/validators.py:196
+#: app/forms/validations/validators.py:199
 msgid "validate.disability_degree.invalid_number"
 msgstr ""
 "Der Grad der Behinderung wird in 5er-Schritten bis 100 festgesetzt. "

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -433,9 +433,12 @@ const translations = {
   revocation: {
     failure: {
       header: {
-        title: "Stornierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
-        intro:
-          "Sind Sie vielleicht noch nicht bei uns registriert? In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt? Dann haben wir Ihren Freischaltcode automatisiert storniert und Sie müssen nichts weiter tun.",
+        title: "Stornierung fehlgeschlagen",
+        reason: {
+          title: "Mögliche Ursachen:",
+          one: "<strong>Sind Sie vielleicht noch nicht bei uns registriert?</strong> In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. <registrationLink>Registrieren</registrationLink> Sie sich, um den Steuerlotsen zu nutzen.",
+          two: "<strong>Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt?</strong>  Dann haben wir Ihren Freischaltcode automatisch storniert und Sie müssen nichts weiter tun.",
+        },
       },
     },
   },

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -251,11 +251,11 @@ const translations = {
       causes: {
         title: "Mögliche Ursachen",
         reasons1:
-          "Ihr Freischaltcode ist nicht korrekt. Eine Ursache kann die Verwechslung von Ziffern oder Buchstaben sein, die sich ähneln. So kann die Ziffer 0 schnell mit dem Buchstaben O oder der Buchstabe B schnell mit der Ziffer 8 verwechselt werden. Prüfen Sie Ihre Angabe.",
+          "<strong>Ihr Freischaltcode ist nicht korrekt.</strong> Eine Ursache kann die Verwechslung von Ziffern oder Buchstaben sein, die sich ähneln. So kann die Ziffer 0 schnell mit dem Buchstaben O oder der Buchstabe B schnell mit der Ziffer 8 verwechselt werden. <eligibilityLink>Prüfen</eligibilityLink> Sie Ihre Angabe.",
         reasons2:
-          "Haben Sie sich vor 90 Tagen registriert? In diesem Fall können Sie sich mit diesem Freischaltcode nicht mehr beim Steuerlotsen anmelden. <registrationLink>Registrieren</registrationLink> Sie sich bitte erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode.",
+          "<strong>Haben Sie sich vor 90 Tagen registriert?</strong> In diesem Fall können Sie sich mit diesem Freischaltcode nicht mehr beim Steuerlotsen anmelden. <registrationLink>Registrieren</registrationLink> Sie sich bitte erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode.",
         reasons3:
-          "Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen. Dann ist Ihr Freischaltcode nicht mehr gültig. Bitte <revocationLink>stornieren</revocationLink> Sie Ihren Freischaltcode und <registrationLink>registrieren</registrationLink> sich erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode.",
+          "<strong>Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen.</strong> Dann ist Ihr Freischaltcode nicht mehr gültig. Bitte <revocationLink>stornieren</revocationLink> Sie Ihren Freischaltcode und registrieren sich erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode.",
       },
     },
   },

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -413,9 +413,16 @@ const translations = {
     },
     failure: {
       header: {
-        title: "Registrierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
+        title: "Registrierung fehlgeschlagen.",
         intro:
           "Haben Sie sich vielleicht bereits registriert? In diesem Fall können Sie sich nicht erneut registrieren und bekommen einen Brief mit Ihrem persönlichen Freischaltcode von Ihrer Finanzverwaltung zugeschickt.",
+      },
+      reasons: {
+        title: "Mögliche Ursachen:",
+        one: "<strong>Ihre Angaben sind nicht korrekt.</strong> <eligibilityLink>Prüfen</eligibilityLink> Sie, ob Sie Ihre Steuer-ID und Ihr Geburtsdatum korrekt eingegeben haben.",
+        two: "<strong>Sie haben sich bereits bei uns registriert.</strong> In diesem Fall können Sie sich nicht erneut registrieren und bekommen einen Brief mit Ihrem persönlichen Freischaltcode von Ihrer Finanzverwaltung zugeschickt.",
+        three:
+          "<strong>Haben Sie sich noch nicht bei uns registriert und die Registrierung klappt trotzdem nicht?</strong> <revocationLink>Stornieren</revocationLink> Sie erst Ihren Freischaltcode und versuchen Sie dann erneut die Registrierung.",
       },
     },
     icons: {

--- a/webapp/client/src/pages/LoginFailurePage.js
+++ b/webapp/client/src/pages/LoginFailurePage.js
@@ -19,6 +19,30 @@ export default function LoginFailurePage({
   revocationLink,
 }) {
   const { t } = useTranslation();
+
+  function trans(key) {
+    return (
+      <Trans
+        t={t}
+        i18nKey={key}
+        components={{
+          registrationLink: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a href={registrationLink} />
+          ),
+          revocationLink: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a href={revocationLink} />
+          ),
+          eligibilityLink: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a href="/unlock_code_request/step/data_input" />
+          ),
+        }}
+      />
+    );
+  }
+
   return (
     <>
       <StepHeaderButtons url={prevUrl} />
@@ -27,30 +51,9 @@ export default function LoginFailurePage({
         {t("unlockCodeActivation.failure.causes.title")}
       </FailureReasonsHeadline>
       <ol>
-        <li>{t("unlockCodeActivation.failure.causes.reasons1")}</li>
-        <li>
-          <Trans
-            t={t}
-            i18nKey="unlockCodeActivation.failure.causes.reasons2"
-            components={{
-              // The anchors get content in the translation file
-              // eslint-disable-next-line jsx-a11y/anchor-has-content
-              registrationLink: <a href={registrationLink} />,
-            }}
-          />
-        </li>
-        <li>
-          <Trans
-            t={t}
-            i18nKey="unlockCodeActivation.failure.causes.reasons3"
-            components={{
-              // eslint-disable-next-line jsx-a11y/anchor-has-content
-              registrationLink: <a href={registrationLink} />,
-              // eslint-disable-next-line jsx-a11y/anchor-has-content
-              revocationLink: <a href={revocationLink} />,
-            }}
-          />
-        </li>
+        <li>{trans("unlockCodeActivation.failure.causes.reasons1")}</li>
+        <li>{trans("unlockCodeActivation.failure.causes.reasons2")}</li>
+        <li>{trans("unlockCodeActivation.failure.causes.reasons3")}</li>
       </ol>
     </>
   );

--- a/webapp/client/src/pages/RevocationFailurePage.js
+++ b/webapp/client/src/pages/RevocationFailurePage.js
@@ -1,20 +1,48 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
+import styled from "styled-components";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import FormFailureHeader from "../components/FormFailureHeader";
 
+const FailureReasonsHeadline = styled.h2`
+  &.unlock-code-failure-reasons-headline {
+    margin-top: var(--spacing-09);
+    margin-bottom: var(--spacing-03);
+  }
+`;
 export default function RevocationFailurePage({ prevUrl }) {
   const { t } = useTranslation();
   const stepHeader = {
     title: t("revocation.failure.header.title"),
-    intro: t("revocation.failure.header.intro"),
   };
+
+  function trans(key) {
+    return (
+      <Trans
+        t={t}
+        i18nKey={key}
+        components={{
+          registrationLink: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a href="/unlock_code_request/step/data_input?link_overview=False" />
+          ),
+        }}
+      />
+    );
+  }
 
   return (
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormFailureHeader {...stepHeader} />
+      <FailureReasonsHeadline className="unlock-code-failure-reasons-headline">
+        {t("revocation.failure.header.reason.title")}
+      </FailureReasonsHeadline>
+      <ol>
+        <li>{trans("revocation.failure.header.reason.one")}</li>
+        <li>{trans("revocation.failure.header.reason.two")}</li>
+      </ol>
     </>
   );
 }

--- a/webapp/client/src/pages/RevocationFailurePage.test.js
+++ b/webapp/client/src/pages/RevocationFailurePage.test.js
@@ -6,16 +6,22 @@ const MOCK_PROPS = {
   prevUrl: "/some/prev/path",
 };
 const EXPECTED_HEADER = {
-  title: "Stornierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
-  intro:
-    "Sind Sie vielleicht noch nicht bei uns registriert? In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt? Dann haben wir Ihren Freischaltcode automatisiert storniert und Sie müssen nichts weiter tun.",
+  title: "Stornierung fehlgeschlagen",
+};
+
+const EXPECTED_TEXT = {
+  title: "Mögliche Ursachen:",
 };
 
 describe("RevocationFailureStepPage", () => {
   it("should render step header texts", () => {
     render(<RevocationFailureStepPage {...MOCK_PROPS} />);
     expect(screen.getByText(EXPECTED_HEADER.title)).toBeInTheDocument();
-    expect(screen.getByText(EXPECTED_HEADER.intro)).toBeInTheDocument();
+  });
+
+  it("should render possible causes", () => {
+    render(<RevocationFailureStepPage {...MOCK_PROPS} />);
+    expect(screen.getByText(EXPECTED_TEXT.title)).toBeInTheDocument();
   });
 
   it("should link to the previous page", () => {

--- a/webapp/client/src/pages/UnlockCodeFailurePage.js
+++ b/webapp/client/src/pages/UnlockCodeFailurePage.js
@@ -1,20 +1,53 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
+import styled from "styled-components";
 import FormFailureHeader from "../components/FormFailureHeader";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 
+const FailureReasonsHeadline = styled.h2`
+  &.unlock-code-failure-reasons-headline {
+    margin-top: var(--spacing-09);
+    margin-bottom: var(--spacing-03);
+  }
+`;
 export default function UnlockCodeFailurePage({ prevUrl }) {
   const { t } = useTranslation();
   const stepHeader = {
     title: t("register.failure.header.title"),
-    intro: t("register.failure.header.intro"),
   };
+
+  function trans(key) {
+    return (
+      <Trans
+        t={t}
+        i18nKey={key}
+        components={{
+          eligibilityLink: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a href="/unlock_code_request/step/data_input" />
+          ),
+          revocationLink: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a href="/unlock_code_revocation/step/data_input" />
+          ),
+        }}
+      />
+    );
+  }
 
   return (
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormFailureHeader {...stepHeader} />
+      <FailureReasonsHeadline className="unlock-code-failure-reasons-headline">
+        {t("register.failure.reasons.title")}
+      </FailureReasonsHeadline>
+      <ol>
+        <li>{trans("register.failure.reasons.one")}</li>
+        <li>{trans("register.failure.reasons.two")}</li>
+        <li>{trans("register.failure.reasons.three")}</li>
+      </ol>
     </>
   );
 }

--- a/webapp/client/src/pages/UnlockCodeFailurePage.test.js
+++ b/webapp/client/src/pages/UnlockCodeFailurePage.test.js
@@ -6,16 +6,21 @@ const MOCK_PROPS = {
   prevUrl: "/some/prev/path",
 };
 const EXPECTED_HEADER = {
-  title: "Registrierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
-  intro:
-    "Haben Sie sich vielleicht bereits registriert? In diesem Fall können Sie sich nicht erneut registrieren und bekommen einen Brief mit Ihrem persönlichen Freischaltcode von Ihrer Finanzverwaltung zugeschickt.",
+  title: "Registrierung fehlgeschlagen.",
 };
 
+const EXPECTED_TEXT = {
+  title: "Mögliche Ursachen:",
+};
 describe("UnlockCodeFailurePage", () => {
   it("should render step header texts", () => {
     render(<UnlockCodeFailurePage {...MOCK_PROPS} />);
     expect(screen.getByText(EXPECTED_HEADER.title)).toBeInTheDocument();
-    expect(screen.getByText(EXPECTED_HEADER.intro)).toBeInTheDocument();
+  });
+
+  it("should render possible reasons for failure", () => {
+    render(<UnlockCodeFailurePage {...MOCK_PROPS} />);
+    expect(screen.getByText(EXPECTED_TEXT.title)).toBeInTheDocument();
   });
 
   it("should link to the previous page", () => {

--- a/webapp/client/src/stories/LoginPage.stories.js
+++ b/webapp/client/src/stories/LoginPage.stories.js
@@ -5,7 +5,7 @@ import { Default as StepFormDefault } from "./StepForm.stories";
 import { baseDecorator } from "../../.storybook/decorators";
 
 export default {
-  title: "Pages/Login",
+  title: "Pages/Login Page",
   component: LoginPage,
   decorators: baseDecorator,
 };


### PR DESCRIPTION
# Short Description
- We want to be as clear as possible in our communication through error messages/failure pages in order to avoid as much support as possible

# Changes
- new text for /unlock_code_request/step/unlock_code_failure, /unlock_code_activation/step/unlock_code_failure, /unlock_code_revocation/step/unlock_code_failure pages
- adds validator condition for when someone uses our example unlock code - displaying a specific error-message below the input field.

# Feedback
- any?

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
