### PR TITLE
Stl 2704 change content pages

### DIFF
--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -923,6 +923,7 @@ msgstr ""
 "machen."
 
 #: app/forms/steps/eligibility_steps.py:793
+# TODO change date if needed here
 msgid "form.eligibility.result-intro"
 msgstr ""
 "Als Nächstes können Sie Ihre Zugangsdaten zum Steuerlotsen beantragen. "

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-08-05 14:29+0200\n"
+"POT-Creation-Date: 2022-08-09 11:15+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -16,115 +16,107 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.10.1\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: app/routes.py:76
+#: app/routes.py:75
 msgid "nav.home"
 msgstr "Übersicht"
 
-#: app/routes.py:77
+#: app/routes.py:76
 msgid "nav.how-it-works"
 msgstr "So funktioniert’s"
 
-#: app/routes.py:78
+#: app/routes.py:77
 msgid "nav.eligibility"
 msgstr "Nutzung prüfen"
 
-#: app/routes.py:79
+#: app/routes.py:78
 msgid "nav.register"
 msgstr "Registrieren"
 
-#: app/routes.py:81
+#: app/routes.py:80
 msgid "nav.preparation"
 msgstr "Vorbereiten"
 
-#: app/routes.py:83
+#: app/routes.py:82
 msgid "nav.lotse-form"
 msgstr "Steuererklärung 2021"
 
-#: app/routes.py:85
+#: app/routes.py:84
 msgid "nav.logout"
 msgstr "Abmelden"
 
-#: app/routes.py:89
+#: app/routes.py:88
 msgid "login.not-logged-in-warning"
 msgstr "Sie müssen eingeloggt sein um das zu sehen."
 
-#: app/routes.py:232
+#: app/routes.py:231
 msgid "unlock_code_request.logged_in.title"
 msgstr "Sind Sie sicher, dass Sie sich erneut registrieren möchten?"
 
-#: app/routes.py:233
+#: app/routes.py:232
 msgid "unlock_code_request.logged_in.intro"
 msgstr ""
 "Sie sind bereits angemeldet. Wählen Sie „Zurück zur Steuererklärung, wenn"
 " Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie sich erneut "
 "registrieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:276
+#: app/routes.py:275
 msgid "unlock_code_revocation.logged_in.title"
 msgstr "Sind Sie sicher, dass Sie Ihren Freischaltcode stornieren möchten?"
 
-#: app/routes.py:277
+#: app/routes.py:276
 msgid "unlock_code_revocation.logged_in.intro"
 msgstr ""
 "Sie sind bereits angemeldet. Wählen Sie „Zurück zur Steuererklärung“, "
 "wenn Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie Ihren "
 "Freischaltcode stornieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:290 app/routes.py:548
+#: app/routes.py:289 app/routes.py:524
 msgid "404.header-title"
 msgstr "Fehler 404 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:331
+#: app/routes.py:330
 msgid "contact.header-title"
 msgstr "Kontakt - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:338
+#: app/routes.py:337
 msgid "imprint.header-title"
 msgstr "Impressum - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:345
+#: app/routes.py:344
 msgid "barrierefreiheit.header-title"
 msgstr "Barrierefreiheit - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:352
+#: app/routes.py:351
 msgid "data_privacy.header-title"
 msgstr "Datenschutz - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:359
+#: app/routes.py:358
 msgid "agb.header-title"
 msgstr "Nutzungsbedingungen - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:365
+#: app/routes.py:364
 msgid "about.header-title"
 msgstr "Projektinfos - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:370
+#: app/routes.py:369
 msgid "about_digitalservice.header-title"
 msgstr "Digital Service - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:515
-msgid "freeTaxDeclarationForPensioners.header-title"
-msgstr "Kostenlose Steuererklärung für Rentner | Steuerlotse Rente"
-
-#: app/routes.py:523
-msgid "mandateForTaxDeclaration.header-title"
-msgstr "Steuererklärung für Eltern machen | Steuerlotse-Rente"
-
-#: app/routes.py:539 app/routes.py:569 app/routes.py:576
+#: app/routes.py:515 app/routes.py:545 app/routes.py:552
 msgid "erica-error.header-title"
 msgstr "Übermittlungsfehler - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:544 app/routes.py:552
+#: app/routes.py:520 app/routes.py:528
 msgid "400.header-title"
 msgstr "Fehler 400 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:557
+#: app/routes.py:533
 msgid "429.header-title"
 msgstr "Fehler 429 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:563
+#: app/routes.py:539
 msgid "500.header-title"
 msgstr "Fehler 500 - Der Steuerlotse für Rente und Pension"
 
@@ -934,7 +926,8 @@ msgstr ""
 msgid "form.eligibility.result-intro"
 msgstr ""
 "Als Nächstes können Sie Ihre Zugangsdaten zum Steuerlotsen beantragen. "
-"Die Registrierung dauert nur 2 Minuten."
+"Die <strong>Registrierung</strong> ist <strong>noch bis einschließlich "
+"30. November 2022 möglich.</strong>"
 
 #: app/forms/steps/eligibility_steps.py:806
 msgid "form.eligibility.result-note.registration-success"
@@ -5495,4 +5488,10 @@ msgstr "Religion"
 #: app/templates/unlock_code/already_logged_in.html:15
 msgid "form.unlock_code.back-to-lotse"
 msgstr "Zurück zur Steuererklärung"
+
+#~ msgid "freeTaxDeclarationForPensioners.header-title"
+#~ msgstr "Kostenlose Steuererklärung für Rentner | Steuerlotse Rente"
+
+#~ msgid "mandateForTaxDeclaration.header-title"
+#~ msgstr "Steuererklärung für Eltern machen | Steuerlotse-Rente"
 

--- a/webapp/client/src/components/AccordionComponent.js
+++ b/webapp/client/src/components/AccordionComponent.js
@@ -83,7 +83,7 @@ export default function AccordionComponent({
   const [toggle, setToggle] = useState();
 
   useEffect(() => {
-    if (/[0-9]+$/.test(window.location.hash)) {
+    if (window.location.hash.includes("-")) {
       const splitted = window.location.hash.split("-");
       window.location = `${splitted[0]}`;
       document

--- a/webapp/client/src/components/AccordionComponent.js
+++ b/webapp/client/src/components/AccordionComponent.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Accordion, Card } from "react-bootstrap";
@@ -32,6 +32,7 @@ const CardHeaderElement = styled.div`
 const ExpandButton = styled.button`
   border: 0;
   background: inherit;
+
   &:focus {
     outline: 0;
   }
@@ -81,6 +82,16 @@ export default function AccordionComponent({
 }) {
   const [toggle, setToggle] = useState();
 
+  useEffect(() => {
+    if (/[0-9]+$/.test(window.location.hash)) {
+      const splitted = window.location.hash.split("-");
+      window.location = `${splitted[0]}`;
+      document
+        .getElementById(`button-${splitted[0].slice(1)}-${splitted[1]}`)
+        .click();
+    }
+  });
+
   return (
     <>
       {title.length > 0 && (
@@ -106,7 +117,10 @@ export default function AccordionComponent({
                   });
                 }}
               >
-                <ExpandButton className="col text-left">
+                <ExpandButton
+                  className="col text-left"
+                  id={`button-${id}-${index}`}
+                >
                   <CardHeaderSpan>{item.title}</CardHeaderSpan>
                 </ExpandButton>
                 <ExpandButton tabIndex={-1} className="col-1">

--- a/webapp/client/src/lib/faqAnchors.js
+++ b/webapp/client/src/lib/faqAnchors.js
@@ -58,6 +58,7 @@ function trans(key) {
     />
   );
 }
+
 const faqAnchorList = [
   {
     title: t("LandingPage.Accordion.Item1.title"),
@@ -76,6 +77,15 @@ const faqAnchorList = [
           <li>{t("LandingPage.Accordion.Item2.listItem5")}</li>
         </ul>
         <p>{trans("LandingPage.Accordion.Item2.detail2")}</p>
+      </div>
+    ),
+  },
+  {
+    title: t("LandingPage.Accordion.Item3.title"),
+    detail: (
+      <div>
+        <p>{t("LandingPage.Accordion.Item3.detail1")}</p>
+        <p>{trans("LandingPage.Accordion.Item3.detail2")}</p>
       </div>
     ),
   },

--- a/webapp/client/src/lib/faqAnchors.js
+++ b/webapp/client/src/lib/faqAnchors.js
@@ -1,5 +1,6 @@
 import { t } from "i18next";
 import { Trans } from "react-i18next";
+import retirementDates from "./retirementDate";
 
 function trans(key) {
   return (
@@ -54,6 +55,10 @@ function trans(key) {
           // eslint-disable-next-line jsx-a11y/anchor-has-content
           <a href="/sofunktionierts" />
         ),
+      }}
+      values={{
+        dateTwo: retirementDates.dateTwo,
+        dateOne: retirementDates.dateOne,
       }}
     />
   );

--- a/webapp/client/src/lib/helperPageFaqAnchors.js
+++ b/webapp/client/src/lib/helperPageFaqAnchors.js
@@ -1,5 +1,7 @@
 import { t } from "i18next";
 import { Trans } from "react-i18next";
+import React from "react";
+import { toggleManually } from "./helpers";
 
 function trans(key) {
   return (
@@ -54,10 +56,20 @@ function trans(key) {
           // eslint-disable-next-line jsx-a11y/anchor-has-content
           <a href="https://www.bzst.de/SiteGlobals/Kontaktformulare/DE/Steuerliche_IDNr/Mitteilung_IdNr/mitteilung_IdNr_node.html" />
         ),
+        validity: (
+          // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+          <a
+            href="#"
+            onClick={(event) =>
+              toggleManually(event, false, "letterActivationCodeSection", "2")
+            }
+          />
+        ),
       }}
     />
   );
 }
+
 const accordionCanIUseSection = [
   {
     title: t("helpAreaPage.accordionCanIUseSection.item1.title"),

--- a/webapp/client/src/lib/helpers.js
+++ b/webapp/client/src/lib/helpers.js
@@ -10,3 +10,13 @@ export default function addPlausibleGoal(plausibleDomain, name, props) {
     window.plausible(name, props);
   }
 }
+
+export function toggleManually(event, moveToNewPage, section, elementIndex) {
+  event.preventDefault();
+  if (moveToNewPage) {
+    window.location = `/hilfebereich#${section}-${elementIndex}`;
+  } else {
+    window.location = `#${section}`;
+    document.getElementById(`button-${section}-${elementIndex}`).click();
+  }
+}

--- a/webapp/client/src/lib/retirementDate.js
+++ b/webapp/client/src/lib/retirementDate.js
@@ -1,0 +1,6 @@
+const retirementDates = {
+  dateOne: "30. November 2022",
+  dateTwo: "20. Dezember 2022",
+};
+
+export default retirementDates;

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -245,7 +245,7 @@ const translations = {
     form: {
       title: "Melden Sie sich mit Ihrem Freischaltcode an",
       intro:
-        "Wenn Sie verpflichtet sind eine Steuererklärung für 2021 abzugeben, ist die <strong>Abgabefrist</strong> der <strong>31. Oktober 2022</strong>. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1. November 2022 als Fristende. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
+        "<strong>Die Abgabe der Steuererklärung mit dem Steuerlotsen ist noch bis einschließlich 20. Dezember 2022 möglich.</strong> Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
     },
     unlockCode: {
       labelText: "Freischaltcode",
@@ -260,9 +260,9 @@ const translations = {
         reasons1:
           "<strong>Ihr Freischaltcode ist nicht korrekt.</strong> Eine Ursache kann die Verwechslung von Ziffern oder Buchstaben sein, die sich ähneln. So kann die Ziffer 0 schnell mit dem Buchstaben O oder der Buchstabe B schnell mit der Ziffer 8 verwechselt werden. <eligibilityLink>Prüfen</eligibilityLink> Sie Ihre Angabe.",
         reasons2:
-          "<strong>Haben Sie sich vor 90 Tagen registriert?</strong> In diesem Fall können Sie sich mit diesem Freischaltcode nicht mehr beim Steuerlotsen anmelden. <registrationLink>Registrieren</registrationLink> Sie sich bitte erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode.",
+          "<strong>Haben Sie sich vor 90 Tagen registriert?</strong> In diesem Fall können Sie sich mit diesem Freischaltcode nicht mehr beim Steuerlotsen anmelden. <registrationLink>Registrieren</registrationLink> Sie sich bitte erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode. Die Registrierung ist noch bis einschließlich 30. November 2022 möglich.",
         reasons3:
-          "<strong>Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen.</strong> Dann ist Ihr Freischaltcode nicht mehr gültig. Bitte <revocationLink>stornieren</revocationLink> Sie Ihren Freischaltcode und registrieren sich erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode.",
+          "<strong>Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen.</strong> Dann ist Ihr Freischaltcode nicht mehr gültig. Bitte <revocationLink>stornieren</revocationLink> Sie Ihren Freischaltcode und registrieren sich erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode. Die Registrierung ist noch bis einschließlich 30. November 2022 möglich.",
       },
     },
   },
@@ -297,6 +297,10 @@ const translations = {
     input: {
       intro:
         "Mit Ihrer Registrierung beantragen Sie einen Freischaltcode bei Ihrer Finanzverwaltung. Sie erhalten diesen <bold>mit einem Brief innerhalb von zwei Wochen</bold> nach erfolgreicher Beantragung. Wenn Sie die Zusammenveranlagung nutzen möchten, reicht es aus, wenn sich eine Person registriert.",
+    },
+    shutDown: {
+      title: "Ich möchte mich für die Steuererklärung 2022 registrieren.",
+      text: "Der Steuerlotse als Online-Dienst wird zum 20. Dezember 2022 eingestellt. Für Ihre Steuererklärung 2022 können Sie im nächsten Jahr einfachELSTER nutzen. Dieser Dienst bietet ebenfalls kostenlos eine vereinfachte Steuererklärung für Rentnerinnen und Renter an.",
     },
   },
   newsletter: {
@@ -380,6 +384,11 @@ const translations = {
       heading: "Wir löschen Ihr Nutzerkonto",
       text: "Bitte beachten Sie, dass Sie Ihren Freischaltcode nicht erneut verwenden können. Wenn Sie unseren Service nächstes Jahr wieder nutzen möchten, können Sie sich einfach erneut registrieren. Haben Sie Ihre Steuererklärung gespeichert? Dann können Sie sich abmelden.",
     },
+    shutDown: {
+      heading: "Der Steuerlotse geht in Rente",
+      text: "Der Steuerlotse als Online-Dienst wird eingestellt. Ihr Nutzerkonto beim Steuerlotsen wird gelöscht. Für Ihre Steuererklärung 2022 können Sie <einfachELSTER>einfachELSTER</einfachELSTER> nutzen. Dieser Dienst bietet ebenfalls eine vereinfachte Steuererklärung für Rentnerinnen und Renter an und ist ein offizielles und kostenloses Angebot der Finanzbehörden.",
+      url: "https://einfach.elster.de/erklaerung/ui/",
+    },
   },
   dateField: {
     day: "Tag",
@@ -413,6 +422,8 @@ const translations = {
             textOne:
               "Wenn Sie den Brief erhalten haben und vorbereitet sind, gehen Sie erneut auf steuerlotse-rente.de. Wählen Sie den Menüpunkt „Ihre Steuererklärung“ und melden Sie sich mit Ihrem Freischaltcode an. Nach der Anmeldung können Sie das Steuerformular ausfüllen und verschicken.",
             textTwo:
+              "<strong>Die Abgabe der Steuererklärung mit dem Steuerlotsen ist noch bis einschließlich 20. Dezember 2022 möglich.</strong> Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
+            textThree:
               "Wenn Sie verpflichtet sind eine Steuererklärung für 2021 abzugeben, ist die <strong>Abgabefrist</strong> der <strong>31. Oktober 2022</strong>. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1. November 2022 als Fristende. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
           },
         },
@@ -461,7 +472,7 @@ const translations = {
         title: "Stornierung fehlgeschlagen",
         reason: {
           title: "Mögliche Ursachen:",
-          one: "<strong>Sind Sie vielleicht noch nicht bei uns registriert?</strong> In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. <registrationLink>Registrieren</registrationLink> Sie sich, um den Steuerlotsen zu nutzen.",
+          one: "<strong>Sind Sie vielleicht noch nicht bei uns registriert?</strong> In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. <registrationLink>Registrieren</registrationLink> Sie sich, um den Steuerlotsen zu nutzen. Die Registrierung ist noch bis einschließlich 30. November 2022 möglich.",
           two: "<strong>Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt?</strong>  Dann haben wir Ihren Freischaltcode automatisch storniert und Sie müssen nichts weiter tun.",
         },
       },
@@ -1031,13 +1042,6 @@ const translations = {
         url: "/unlock_code_activation/step/data_input?link_overview=False",
       },
     },
-    Deadline: {
-      header: "Abgabefrist: 31. Oktober 2022",
-      noteOne:
-        "Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1.November 2022.",
-      noteTwo:
-        "Die Abgabefrist gilt für Personen, die verpflichtet sind eine Steuererklärung für das Jahr 2021 abzugeben. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
-    },
     Accordion: {
       heading: "Häufige Fragen und Antworten",
       Item1: {
@@ -1060,6 +1064,13 @@ const translations = {
           "Sie erhalten einen Brief mit einem 12-stelligen Freischaltcode.",
         listItem5:
           "Melden Sie sich mit Ihrem Freischaltcode an und füllen Ihre Steuererklärung aus.",
+      },
+      Item3: {
+        title: "Bis wann kann ich die Steuererklärung abgeben?",
+        detail1:
+          "Wenn Sie verpflichtet sind eine Steuererklärung für 2021 abzugeben, ist die Abgabefrist der 31. Oktober 2022. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1. November 2022 als Fristende. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
+        detail2:
+          "<strong>Bis einschließlich 20. Dezember 2022</strong> haben Sie noch die Möglichkeit, Ihre Steuererklärung mit dem Steuerlotsen auszufüllen und abzugeben. Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine Gültigkeit verlieren kann.",
       },
       Item5: {
         title: "Können wir die Steuererklärung gemeinsam als Paar machen?",
@@ -1413,6 +1424,8 @@ const translations = {
   },
   helpAreaPage: {
     formHeaderTitle: "Hilfebereich",
+    intro:
+      "Mehr Informationen zur Einstellung des Steuerlotsen finden Sie auf der Seite „Ende des Steuerlotsen“.",
     listOfContents: {
       one: "Kann ich den Steuerlotsen nutzen?",
       two: "Brief und Freischaltcode ",
@@ -1531,8 +1544,8 @@ const translations = {
       item1: {
         title: "Abgabefrist",
         detail: {
-          one: "Wenn Sie verpflichtet sind, eine Steuererklärung abzugeben, muss Ihre Einkommensteuererklärung <strong>bis zum 31. Oktober 2022</strong> beim Finanzamt sein. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1. November 2022 als Fristende.",
-          two: "Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Warten Sie aber lieber nicht allzu lange. Es kann vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag einfordert, wenn Sie sich zu viel Zeit lassen.",
+          one: "Wenn Sie verpflichtet sind eine Steuererklärung für 2021 abzugeben, ist die Abgabefrist der 31. Oktober 2022. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, muss gilt der 1. November 2022 als Fristende. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
+          two: "<strong>Bis einschließlich 20. Dezember 2022</strong> haben Sie noch die Möglichkeit, Ihre Steuererklärung mit dem Steuerlotsen auszufüllen und abzugeben. Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
         },
       },
       item2: {

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -245,7 +245,7 @@ const translations = {
     form: {
       title: "Melden Sie sich mit Ihrem Freischaltcode an",
       intro:
-        "<strong>Die Abgabe der Steuererklärung mit dem Steuerlotsen ist noch bis einschließlich 20. Dezember 2022 möglich.</strong> Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
+        "<strong>Die Abgabe der Steuererklärung mit dem Steuerlotsen ist noch bis einschließlich {{dateTwo}} möglich.</strong> Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
     },
     unlockCode: {
       labelText: "Freischaltcode",
@@ -260,9 +260,9 @@ const translations = {
         reasons1:
           "<strong>Ihr Freischaltcode ist nicht korrekt.</strong> Eine Ursache kann die Verwechslung von Ziffern oder Buchstaben sein, die sich ähneln. So kann die Ziffer 0 schnell mit dem Buchstaben O oder der Buchstabe B schnell mit der Ziffer 8 verwechselt werden. <eligibilityLink>Prüfen</eligibilityLink> Sie Ihre Angabe.",
         reasons2:
-          "<strong>Haben Sie sich vor 90 Tagen registriert?</strong> In diesem Fall können Sie sich mit diesem Freischaltcode nicht mehr beim Steuerlotsen anmelden. <registrationLink>Registrieren</registrationLink> Sie sich bitte erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode. Die Registrierung ist noch bis einschließlich 30. November 2022 möglich.",
+          "<strong>Haben Sie sich vor 90 Tagen registriert?</strong> In diesem Fall können Sie sich mit diesem Freischaltcode nicht mehr beim Steuerlotsen anmelden. <registrationLink>Registrieren</registrationLink> Sie sich bitte erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode. Die Registrierung ist noch bis einschließlich {{dateOne}} möglich.",
         reasons3:
-          "<strong>Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen.</strong> Dann ist Ihr Freischaltcode nicht mehr gültig. Bitte <revocationLink>stornieren</revocationLink> Sie Ihren Freischaltcode und registrieren sich erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode. Die Registrierung ist noch bis einschließlich 30. November 2022 möglich.",
+          "<strong>Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen.</strong> Dann ist Ihr Freischaltcode nicht mehr gültig. Bitte <revocationLink>stornieren</revocationLink> Sie Ihren Freischaltcode und registrieren sich erneut. Sie erhalten dann einen Brief mit einem neuen Freischaltcode. Die Registrierung ist noch bis einschließlich {{dateOne}} möglich.",
       },
     },
   },
@@ -422,7 +422,7 @@ const translations = {
             textOne:
               "Wenn Sie den Brief erhalten haben und vorbereitet sind, gehen Sie erneut auf steuerlotse-rente.de. Wählen Sie den Menüpunkt „Ihre Steuererklärung“ und melden Sie sich mit Ihrem Freischaltcode an. Nach der Anmeldung können Sie das Steuerformular ausfüllen und verschicken.",
             textTwo:
-              "<strong>Die Abgabe der Steuererklärung mit dem Steuerlotsen ist noch bis einschließlich 20. Dezember 2022 möglich.</strong> Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
+              "<strong>Die Abgabe der Steuererklärung mit dem Steuerlotsen ist noch bis einschließlich {{dateTwo}} möglich.</strong> Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine <validity>Gültigkeit</validity> verlieren kann.",
             textThree:
               "Wenn Sie verpflichtet sind eine Steuererklärung für 2021 abzugeben, ist die <strong>Abgabefrist</strong> der <strong>31. Oktober 2022</strong>. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1. November 2022 als Fristende. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
           },
@@ -472,7 +472,7 @@ const translations = {
         title: "Stornierung fehlgeschlagen",
         reason: {
           title: "Mögliche Ursachen:",
-          one: "<strong>Sind Sie vielleicht noch nicht bei uns registriert?</strong> In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. <registrationLink>Registrieren</registrationLink> Sie sich, um den Steuerlotsen zu nutzen. Die Registrierung ist noch bis einschließlich 30. November 2022 möglich.",
+          one: "<strong>Sind Sie vielleicht noch nicht bei uns registriert?</strong> In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. <registrationLink>Registrieren</registrationLink> Sie sich, um den Steuerlotsen zu nutzen. Die Registrierung ist noch bis einschließlich {{dateOne}} möglich.",
           two: "<strong>Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt?</strong>  Dann haben wir Ihren Freischaltcode automatisch storniert und Sie müssen nichts weiter tun.",
         },
       },
@@ -1070,7 +1070,7 @@ const translations = {
         detail1:
           "Wenn Sie verpflichtet sind eine Steuererklärung für 2021 abzugeben, ist die Abgabefrist der 31. Oktober 2022. Wenn dieser Tag in Ihrem Bundesland ein Feiertag ist, gilt der 1. November 2022 als Fristende. Sie können Ihre Steuererklärung auch nach der Frist noch einreichen. Dann kann es allerdings vorkommen, dass Ihr Finanzamt einen Verspätungszuschlag erhebt.",
         detail2:
-          "<strong>Bis einschließlich 20. Dezember 2022</strong> haben Sie noch die Möglichkeit, Ihre Steuererklärung mit dem Steuerlotsen auszufüllen und abzugeben. Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine Gültigkeit verlieren kann.",
+          "<strong>Bis einschließlich {{dateTwo}}</strong> haben Sie noch die Möglichkeit, Ihre Steuererklärung mit dem Steuerlotsen auszufüllen und abzugeben. Bitte beachten Sie, dass Ihr Freischaltcode bereits vorher seine Gültigkeit verlieren kann.",
       },
       Item5: {
         title: "Können wir die Steuererklärung gemeinsam als Paar machen?",

--- a/webapp/client/src/pages/HelpAreaPage.js
+++ b/webapp/client/src/pages/HelpAreaPage.js
@@ -41,10 +41,12 @@ export default function HelpAreaPage({ plausibleDomain }) {
   const plausiblePropsContactUsButton = {
     method: "Hilfebereich / Schreiben Sie uns",
   };
+
   return (
     <>
       <ContentWrapper>
         <FormHeader title={t("helpAreaPage.formHeaderTitle")} />
+        <p>{t("helpAreaPage.intro")}</p>
         <TableOfContents>
           <Row>
             <Icon src={IconOne} alt="test" />

--- a/webapp/client/src/pages/LandingPage.js
+++ b/webapp/client/src/pages/LandingPage.js
@@ -154,9 +154,6 @@ export default function LandingPage({ plausibleDomain }) {
       </LandingPageHeroWrapper>
       <CardsComponent cards={cardsInfo} />
       <AccordionWrapper>
-        <h2>{t("LandingPage.Deadline.header")}</h2>
-        <p>{t("LandingPage.Deadline.noteOne")}</p>
-        <p>{t("LandingPage.Deadline.noteTwo")}</p>
         <AccordionComponent
           title={t("LandingPage.Accordion.heading")}
           items={faqAnchorList}

--- a/webapp/client/src/pages/LoginFailurePage.js
+++ b/webapp/client/src/pages/LoginFailurePage.js
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import styled from "styled-components";
 import FormFailureHeader from "../components/FormFailureHeader";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import retirementDates from "../lib/retirementDate";
 
 const FailureReasonsHeadline = styled.h2`
   &.unlock-code-failure-reasons-headline {
@@ -38,6 +39,10 @@ export default function LoginFailurePage({
             // eslint-disable-next-line jsx-a11y/anchor-has-content
             <a href="/unlock_code_request/step/data_input" />
           ),
+        }}
+        values={{
+          dateTwo: retirementDates.dateTwo,
+          dateOne: retirementDates.dateOne,
         }}
       />
     );

--- a/webapp/client/src/pages/LoginPage.js
+++ b/webapp/client/src/pages/LoginPage.js
@@ -8,6 +8,7 @@ import FormRowCentered from "../components/FormRowCentered";
 import StepFormAsync from "../components/StepFormAsync";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import { fieldPropType } from "../lib/propTypes";
+import { toggleManually } from "../lib/helpers";
 
 export default function LoginPage({ form, fields }) {
   const { t } = useTranslation();
@@ -24,6 +25,15 @@ export default function LoginPage({ form, fields }) {
               href="https://www.bzst.de/DE/Privatpersonen/SteuerlicheIdentifikationsnummer/steuerlicheidentifikationsnummer_node.html"
               target="_blank"
               rel="noreferrer"
+            />
+          ),
+          validity: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+            <a
+              href="#"
+              onClick={(event) =>
+                toggleManually(event, true, "letterActivationCodeSection", "2")
+              }
             />
           ),
         }}

--- a/webapp/client/src/pages/LoginPage.js
+++ b/webapp/client/src/pages/LoginPage.js
@@ -9,6 +9,7 @@ import StepFormAsync from "../components/StepFormAsync";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import { fieldPropType } from "../lib/propTypes";
 import { toggleManually } from "../lib/helpers";
+import retirementDates from "../lib/retirementDate";
 
 export default function LoginPage({ form, fields }) {
   const { t } = useTranslation();
@@ -36,6 +37,10 @@ export default function LoginPage({ form, fields }) {
               }
             />
           ),
+        }}
+        values={{
+          dateTwo: retirementDates.dateTwo,
+          dateOne: retirementDates.dateOne,
         }}
       />
     );

--- a/webapp/client/src/pages/RegistrationPage.js
+++ b/webapp/client/src/pages/RegistrationPage.js
@@ -72,6 +72,9 @@ export default function RegistrationPage({
           />
         }
       />
+      <Details title={t("unlockCodeRequest.shutDown.title")} detailsId="123">
+        <p>{t("unlockCodeRequest.shutDown.text")}</p>
+      </Details>
       <StepFormAsync
         {...form}
         sendDisableCall={sendDisableCall}

--- a/webapp/client/src/pages/RevocationFailurePage.js
+++ b/webapp/client/src/pages/RevocationFailurePage.js
@@ -4,6 +4,7 @@ import { useTranslation, Trans } from "react-i18next";
 import styled from "styled-components";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import FormFailureHeader from "../components/FormFailureHeader";
+import retirementDates from "../lib/retirementDate";
 
 const FailureReasonsHeadline = styled.h2`
   &.unlock-code-failure-reasons-headline {
@@ -27,6 +28,10 @@ export default function RevocationFailurePage({ prevUrl }) {
             // eslint-disable-next-line jsx-a11y/anchor-has-content
             <a href="/unlock_code_request/step/data_input?link_overview=False" />
           ),
+        }}
+        values={{
+          dateTwo: retirementDates.dateTwo,
+          dateOne: retirementDates.dateOne,
         }}
       />
     );

--- a/webapp/client/src/pages/SubmitAcknowledgePage.js
+++ b/webapp/client/src/pages/SubmitAcknowledgePage.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import FormSuccessHeader from "../components/FormSuccessHeader";
 import AnchorButton from "../components/AnchorButton";
@@ -27,6 +27,23 @@ export default function SubmitAcknowledgePage({ prevUrl, logoutUrl }) {
       </p>
       <h2 className="h4 mt-5">{t("submitAcknowledge.logout.heading")}</h2>
       <p className="mb-5">{t("submitAcknowledge.logout.text")}</p>
+      <h2 className="h4 mt-5">{t("submitAcknowledge.shutDown.heading")}</h2>
+      <p className="mb-5">
+        <Trans
+          t={t}
+          i18nKey="submitAcknowledge.shutDown.text"
+          components={{
+            einfachELSTER: (
+              // eslint-disable-next-line jsx-a11y/anchor-has-content
+              <a
+                href={t("submitAcknowledge.shutDown.url")}
+                rel="noreferrer"
+                target="_blank"
+              />
+            ),
+          }}
+        />
+      </p>
       <AnchorButton
         url={logoutUrl}
         text={t("form.logout.button")}

--- a/webapp/client/src/pages/UnlockCodeSuccessPage.js
+++ b/webapp/client/src/pages/UnlockCodeSuccessPage.js
@@ -10,6 +10,7 @@ import TwoIcon from "../assets/icons/Icon-2.svg";
 import ThreeIcon from "../assets/icons/Icon-3.svg";
 import NewsletterRegisterBox from "../components/NewsletterRegisterBox";
 import { toggleManually } from "../lib/helpers";
+import retirementDates from "../lib/retirementDate";
 
 export default function UnlockCodeSuccessPage({
   prevUrl,
@@ -85,6 +86,10 @@ export default function UnlockCodeSuccessPage({
               }
             />
           ),
+        }}
+        values={{
+          dateTwo: retirementDates.dateTwo,
+          dateOne: retirementDates.dateOne,
         }}
       />
     );

--- a/webapp/client/src/pages/UnlockCodeSuccessPage.js
+++ b/webapp/client/src/pages/UnlockCodeSuccessPage.js
@@ -9,6 +9,7 @@ import OneIcon from "../assets/icons/Icon-1.svg";
 import TwoIcon from "../assets/icons/Icon-2.svg";
 import ThreeIcon from "../assets/icons/Icon-3.svg";
 import NewsletterRegisterBox from "../components/NewsletterRegisterBox";
+import { toggleManually } from "../lib/helpers";
 
 export default function UnlockCodeSuccessPage({
   prevUrl,
@@ -75,6 +76,15 @@ export default function UnlockCodeSuccessPage({
             // eslint-disable-next-line jsx-a11y/anchor-has-content
             <a href="/vorbereiten" rel="noreferrer" target="_blank" />
           ),
+          validity: (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+            <a
+              href="#"
+              onClick={(event) =>
+                toggleManually(event, true, "letterActivationCodeSection", "2")
+              }
+            />
+          ),
         }}
       />
     );
@@ -86,9 +96,12 @@ export default function UnlockCodeSuccessPage({
       <p>
         {trans("register.success.next-steps.howItContinues.step-3.textTwo")}
       </p>
+      <p>
+        {trans("register.success.next-steps.howItContinues.step-3.textThree")}
+      </p>
     </>
   );
-        
+
   const imageDescription = (
     <>
       <p>
@@ -101,9 +114,9 @@ export default function UnlockCodeSuccessPage({
           "register.success.next-steps.howItContinues.step-2.imageDescriptionTwo"
         )}
       </p>
-      </>
+    </>
   );
-        
+
   return (
     <>
       <StepHeaderButtons url={prevUrl} />


### PR DESCRIPTION
# Short Description
- Updates on content pages according to the retirement phase 1.

# Changes
- Updated texts
- Cherry picked implementation with the deadlines variables using the js file.
- On the LandingPage, as agreed, the deadline text above the accordion has been removed and the old accordion element readded with the new text.
- On the success page of the eligibility process you can find the dateOne of the deadlines (supposed to be dynamic) but this is the only page using one of those deadlines that hasn't been reactified yet. Therefore we agreed to leave it hard-coded and noted with a TODO in the .po file
- Added collapsing+jumping capability when using the link of "Gültigkeit"

# Feedback
- Any?

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
