### PR TITLE
NO_TICKET | Remove adding tax id number in revocation of cron jobs

### DIFF
--- a/webapp/app/commands.py
+++ b/webapp/app/commands.py
@@ -117,7 +117,6 @@ def _revoke_permission_and_delete_users(users_to_delete, success_message):
                 'elster_request_id': user_to_delete.elster_request_id}
         else:
             form_data = {
-                'idnr': user_to_delete.idnr_hashed,
                 'elster_request_id': user_to_delete.elster_request_id}
         try:
             elster_client.send_unlock_code_revocation_with_elster(form_data, 'CRONJOB-IP')

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -94,7 +94,6 @@ def send_est_with_elster(form_data, ip_address, year=VERANLAGUNGSJAHR):
     return _extract_est_response_data_v2(result)
 
 
-
 def validate_est_with_elster(form_data, year=VERANLAGUNGSJAHR, include_elster_responses=True):
     """The overarching method that is being called from the web backend. It
     will send the form data for an ESt to the PyERiC server and then extract information from the response.
@@ -135,7 +134,9 @@ def send_unlock_code_activation_with_elster(form_data, elster_request_id, ip_add
 
 
 def send_unlock_code_revocation_with_elster(form_data, ip_address):
-    data = {'payload': {'tax_id_number': form_data['idnr'], 'elster_request_id': form_data['elster_request_id']},
+    data = {'payload': {'tax_id_number': form_data['idnr'],
+                        'elster_request_id': form_data['elster_request_id']} if 'idnr' in form_data else {
+        'elster_request_id': form_data['elster_request_id']},
             'client_identifier': Config.ERICA_CLIENT_IDENTIFIER}
     result = _send_job_and_get_result('fsc/revocation', data)
     create_audit_log_entry('unlock_code_revocation_sent',

--- a/webapp/tests/elster_client/mock_erica.py
+++ b/webapp/tests/elster_client/mock_erica.py
@@ -213,7 +213,7 @@ class MockErica:
     def revoke_unlock_code(input_data):
 
         # unexpected input data
-        if not input_data.get('tax_id_number') or not input_data.get('elster_request_id'):
+        if not input_data.get('elster_request_id'):
             raise UnexpectedInputDataError()
 
         idnr_exists = False


### PR DESCRIPTION
# Short Description
- Fix validation error in unlock code revocation of cron jobs

# Changes
- Remove sending the hashed tax id number when revocating unlock code in the cron jobs

# Feedback
- Not needed for the normal flow through the client since the real tax id number is used (and not the hashed one)

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
